### PR TITLE
use stable version of rate

### DIFF
--- a/rate.Dockerfile
+++ b/rate.Dockerfile
@@ -2,6 +2,6 @@
 FROM jixone/rust-ci:rust-stable
 USER root
 
-RUN cargo install --git https://github.com/krobelus/rate --rev d5095c5f24acee2fabd6d2c8499ad0186ddafcb3
+RUN cargo install rate
 
 USER circleci


### PR DESCRIPTION
rate now has stable releases on crates.io